### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
     
       <%  @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image.variant(resize: '500x500'), class: 'item-img' if item.image.attached? %>
             </div>
@@ -189,3 +189,4 @@
 <% end %>
 
 <%= render "shared/footer" %>
+

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,43 +1,53 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
+      <%# <div class="sold-out">
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       <%= "#{@item.item_price}円" %>
       </span>
+
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <% shipmentfee = Shipmentfee.find_by(id: @item.shipmentfee_id) %>
+        <span><%= shipmentfee&.name %></span>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+  <% if user_signed_in? %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+  <%else%>
+  <%end%>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <%# <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%> 
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+   <% if user_signed_in? && current_user.id != @item.user_id %>
+    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+  <%else%>
+  <%end%>
+
+
+
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.name %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -47,23 +57,28 @@
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><% category = Category.find_by(id: @item.category_id) %><span><%= category&.name %></span>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><% status = Status.find_by(id: @item.status_id) %><span><%= status&.name %></span>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><% shipmentfee = Shipmentfee.find_by(id: @item.shipmentfee_id) %><span><%= shipmentfee&.name %></span>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><% prefecture = Prefecture.find_by(id: @item.prefecture_id) %><span><%= prefecture&.name %></span>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><% waitingday = Waitingday.find_by(id: @item.waitingday_id) %><span><%= waitingday&.name %></span>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -78,7 +93,7 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
+  
 
   <div class="comment-box">
     <form>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,20 +24,19 @@
       </span>
     </div>
 
-
-  <% if user_signed_in? && current_user.id == @item.user_id%>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-  <%else%>
+  <% if user_signed_in?%>
+   <% if current_user.id == @item.user_id%>
+     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+     <p class="or-text">or</p>
+     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+   <%else%>
+     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+   <%end%>
   <%end%>
+
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%# <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%> 
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-   <% if user_signed_in? && current_user.id != @item.user_id %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-  <%else%>
-  <%end%>
 
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,6 @@
     </div>
 
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
   <% if user_signed_in? && current_user.id == @item.user_id%>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
@@ -44,7 +43,7 @@
 
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
 
     <div class="item-explain-box">
       <span><%= @item.name %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-  <% if user_signed_in? %>
+  <% if user_signed_in? && current_user.id == @item.user_id%>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
@@ -53,7 +53,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
@@ -117,9 +117,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><% category = Category.find_by(id: @item.category_id) %><span><%= category&.name %></span>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
# What 
商品詳細表示機能の実装

# Why
ユーザーが出品した商品の詳しい情報を表示させるため。

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/69fff46d163eaaa66bacbd9d445a20cf

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/c4cbf3a85a96b63df8358333c365f581

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
未実装

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/14c909d1f9142f00a0f4819524ced53f

よろしくお願いいたします。
